### PR TITLE
handle viewers/broadcasters leaving event

### DIFF
--- a/client/broadcast.js
+++ b/client/broadcast.js
@@ -38,6 +38,8 @@ socket.on('connect', () => {
     }  
   });
 
+
+
 });
 
 sendEventTag = () => {

--- a/client/events.html
+++ b/client/events.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 	<a href = 'index.html'><button>Home</button></a>
+	<h1>Choose an Event!</h1>
 	<div id = 'eventList'>
   </div>
 	<script src='/socket.io/socket.io.js'></script>

--- a/client/viewer.js
+++ b/client/viewer.js
@@ -60,6 +60,13 @@ socket.on('connect', () => {
       //   console.log('got a message from broadcaster: ' + msg);
       // });
     }
+   
+  //redirect viewer to events page if there are no more broadcasters streaming their event
+  socket.on('redirectToEvents', (destination) => {
+    console.log('redirecting viewer to events page');
+    window.location.href = destination;
+  });
+
     // var viewerPeer = new SimplePeer({initiator: false});
 
     // viewerPeer.on('signal', (data) => {

--- a/client/viewer.js
+++ b/client/viewer.js
@@ -52,9 +52,9 @@ socket.on('connect', () => {
         console.log('got a stream from broadcaster');
         // got remote video stream, now let's show it in a video tag
         var video = $('#broadcast1')[0];
-        video.src = window.URL.createObjectURL(stream)
-        video.play()
-      })
+        video.src = window.URL.createObjectURL(stream);
+        video.play();
+      });
 
       // viewerPeer.on('data', (msg) => {
       //   console.log('got a message from broadcaster: ' + msg);

--- a/server/server.js
+++ b/server/server.js
@@ -87,14 +87,15 @@ io.on('connection', (socket) => {
         delete eventTracker[eventTag].broadcasters[socket.id];
         console.log('eventTracker[eventTag]', eventTracker[eventTag]);
         if(Object.keys(eventTracker[eventTag].broadcasters).length === 0){
+          
           console.log('no more broadcasters for this event');
           if (Object.keys(eventTracker[eventTag].viewers).length){
             for (var viewer in eventTracker[eventTag].viewers){
               //redirect viewers to events.html
-              console.log('viewer is:', viewer);
+              
               var destination = './events.html';
               io.to(viewer).emit('redirectToEvents', destination);
-              console.log('in for loop');
+              delete eventTracker[eventTag];
             }
           }
           

--- a/server/server.js
+++ b/server/server.js
@@ -102,7 +102,7 @@ io.on('connection', (socket) => {
         }
       } 
       else if (eventTracker[key].viewers[socket.id]){
-        console.log('viewer socket disconnected');
+        delete eventTracker[key].viewers[socket.id];
       }
     }
   });

--- a/server/server.js
+++ b/server/server.js
@@ -56,14 +56,15 @@ io.on('connection', (socket) => {
   // listens for initiate view request from viewer
   socket.on('initiateView', (eventTag) => {
     // add this viewer socket to eventTracker
-    eventTracker[eventTag].viewers[socket.id] = socket; // save ref to this socket obj
+    eventTracker[eventTag].viewers[socket.id] = socket.id; // save ref to this socket obj
     console.log('inside initiateView', eventTracker);
 
     // send message to broadcaster that a viewer wants to connected
     var broadcasterSocketId = Object.keys(eventTracker[eventTag].broadcasters)[0]; // for now, pick the 1st broadcaster for this eventTag
     console.log('broadcasterSocketId', broadcasterSocketId);
 
-    // emit a message to broadcaster to initiate connection
+    // server emits a message to broadcaster to initiate connection
+    // socket.id is from viewer
     io.to(broadcasterSocketId).emit('initiateConnection', socket.id);
 
   });
@@ -72,6 +73,37 @@ io.on('connection', (socket) => {
     console.log('inside signal', toId);
     // send the peerObj to the peerId
     io.to(toId).emit('signal', peerObj);
+  });
+
+  //listens for disconnection
+  socket.on('disconnect', () => {
+    console.log('this user left:', socket.id, 'socket:');
+    socket.emit('user disconnected');
+    for (var key in eventTracker){
+      console.log('broadcaster disconnected. eventTracker in for loop:', eventTracker);
+      if (eventTracker[key].broadcasters[socket.id]) {
+        var eventTag = key;
+        console.log('eventTag:', key);
+        delete eventTracker[eventTag].broadcasters[socket.id];
+        console.log('eventTracker[eventTag]', eventTracker[eventTag]);
+        if(Object.keys(eventTracker[eventTag].broadcasters).length === 0){
+          console.log('no more broadcasters for this event');
+          if (Object.keys(eventTracker[eventTag].viewers).length){
+            for (var viewer in eventTracker[eventTag].viewers){
+              //redirect viewers to events.html
+              console.log('viewer is:', viewer);
+              var destination = './events.html';
+              io.to(viewer).emit('redirectToEvents', destination);
+              console.log('in for loop');
+            }
+          }
+          
+        }
+      } 
+      else if (eventTracker[key].viewers[socket.id]){
+        console.log('viewer socket disconnected');
+      }
+    }
   });
 
   //listen for broadcastURL from broadcaster
@@ -92,7 +124,7 @@ io.on('connection', (socket) => {
 
 
 
-http.listen(3000, function(){
+http.listen(3030, function(){
 	console.log('listening on 3000');
 });
 


### PR DESCRIPTION
- remove viewer/broadcaster from eventTracker if they disconnect
- remove event from events page if there are no remaining broadcasters
- redirect viewers to events page if their event no longer exists