### PR TITLE
fix viewer and broadcaster bugs

### DIFF
--- a/client/broadcast2.js
+++ b/client/broadcast2.js
@@ -64,6 +64,15 @@ class ConspectioBroadcaster {
     this.pc.addIceCandidate(new RTCIceCandidate(candidate));
   }
 
+  removeStreamWrapper() {
+    this.pc.removeStream(globalStream);
+    console.log('removeStreamWrapper invoked on broadcast2.js')
+  }
+
+  closeWrapper() {
+    this.pc.close();
+    console.log('broadcast2.js closeWrapper invoked');
+  }
 }
 
 
@@ -137,6 +146,11 @@ stopStream = () => {
   let eventTag = $('#eventTag').val();
   $('#startButton').prop('disabled', false);
   $('#stopButton').prop('disabled', true);
+  for (var conspectioBroadcasterId in connections){
+    connections[conspectioBroadcasterId].removeStreamWrapper();
+    connections[conspectioBroadcasterId].closeWrapper();
+    delete connections[conspectioBroadcasterId];
+  }
   socket.emit('removeBroadcaster', eventTag);
 };
 

--- a/client/viewer2.js
+++ b/client/viewer2.js
@@ -35,13 +35,17 @@ class ConspectioViewer {
     var video = $('<video class="newVideo"></video>').attr(
       {
         'src': window.URL.createObjectURL(event.stream),
-        'autoplay': true
+        'autoplay': true,
+        'id': this.broadcasterId.slice(2)
       });
     $('#videosDiv').append(video);
   }
 
   handleRemoteStreamRemoved(event) {
     console.log('broadcaster stream removed');
+    //remove stream video tag
+
+    $('#' + this.broadcasterId).remove();
   }
 
   handleIceConnectionChange() {
@@ -75,7 +79,13 @@ class ConspectioViewer {
   addCandidate(candidate) {
     this.pc.addIceCandidate(new RTCIceCandidate(candidate));
   }
- 
+  
+  closeWrapper() {
+    this.pc.close();
+    //remove stream video tag
+    $('#' + this.broadcasterId.slice(2)).remove();
+    console.log('broadcaster stream removed from closewrapper');
+  }
 }
 
 const socket = io();
@@ -109,5 +119,11 @@ socket.on('connect', () => {
     console.log('redirecting viewer to events page');
     window.location.href = destination;
   });
+
+  //broadcaster left - close connection & remove from connections object
+  socket.on('broadcasterLeft', (broadcasterId) => {
+    connections[broadcasterId].closeWrapper();
+    delete connections[broadcasterId];
+  })
 
 });


### PR DESCRIPTION
- remove viewer from eventTracker when viewer leaves event
- if viewer leaves event, reenters event, they can now still see a stream
- remove stream when broadcaster leaves
- 2 broadcasters 1 viewer, 1 broadcaster leaves and reenters same event, viewer can still see both